### PR TITLE
Remove header/footer scripts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1348,39 +1348,3 @@ function visualcomposerstarter_inline_styles() {
 	wp_add_inline_style( 'vct-custom-style', $css );
 }
 add_action( 'wp_enqueue_scripts', 'visualcomposerstarter_inline_styles' );
-
-
-/**
- * Inline footer js.
- */
-function vct_inline_footer_js() {
-	$js = '';
-
-	// custom footer scripts.
-	$footer_js = get_theme_mod( 'vct_scripts_footer', '' );
-	$js .= $footer_js;
-
-	wp_add_inline_script( 'visual-composer-starter-script', $js );
-}
-
-add_action( 'wp_enqueue_scripts', 'vct_inline_footer_js' );
-
-/**
- * Inline header js.
- */
-function vct_inline_header_js() {
-	/* Header scripts */
-	wp_register_script( 'visual-composer-starter-header-script', get_template_directory_uri() . '/js/header-scripts.js', array( 'jquery' ), VCT_VERSION, false );
-	/* Enqueue scripts */
-	wp_enqueue_script( 'visual-composer-starter-header-script' );
-
-	$js = '';
-
-	// custom header scripts.
-	$header_js = get_theme_mod( 'vct_scripts_header', '' );
-	$js .= $header_js;
-
-	wp_add_inline_script( 'visual-composer-starter-header-script', $js );
-}
-
-add_action( 'wp_enqueue_scripts', 'vct_inline_header_js' );

--- a/inc/customizer/class-vct-customizer.php
+++ b/inc/customizer/class-vct-customizer.php
@@ -92,7 +92,6 @@ class VCT_Customizer {
 		$this->header_and_menu_section( $wp_customize );
 		$this->footer_section( $wp_customize );
 		$this->fonts_and_style_panel( $wp_customize );
-		$this->scripts( $wp_customize );
 	}
 
 	/**
@@ -1159,52 +1158,6 @@ class VCT_Customizer {
 		$this->fonts_and_style_section_h6( $wp_customize );
 		$this->fonts_and_style_section_body( $wp_customize );
 		$this->fonts_and_style_section_buttons( $wp_customize );
-	}
-
-	/**
-	 * Section: Scripts Section
-	 *
-	 * @param WP_Customize_Manager $wp_customize Customize manager class.
-	 *
-	 * @access private
-	 * @since  1.0
-	 * @return void
-	 */
-	private function scripts( $wp_customize ) {
-		$wp_customize->add_setting( 'vct_scripts_header', array(
-			'default'        => '',
-			'sanitize_callback' => 'wp_strip_all_tags',
-		) );
-		$wp_customize->add_setting( 'vct_scripts_footer', array(
-			'default'        => '',
-			'sanitize_callback' => 'wp_strip_all_tags',
-		) );
-		$wp_customize->add_control(
-			new WP_Customize_Control(
-				$wp_customize,
-				'vct_scripts_header',
-				array(
-					'label'             => esc_html__( 'Header Scripts', 'visual-composer-starter' ),
-					'description'       => esc_html__( 'Add scripts to your theme header (ex. Google Analytics tracking code).', 'visual-composer-starter' ),
-					'section'           => 'vct_scripts',
-					'settings'          => 'vct_scripts_header',
-					'type'              => 'textarea',
-				)
-			)
-		);
-		$wp_customize->add_control(
-			new WP_Customize_Control(
-				$wp_customize,
-				'vct_scripts_footer',
-				array(
-					'label'             => esc_html__( 'Footer Scripts', 'visual-composer-starter' ),
-					'description'       => esc_html__( 'Add scripts to your theme footer.', 'visual-composer-starter' ),
-					'section'           => 'vct_scripts',
-					'settings'          => 'vct_scripts_footer',
-					'type'              => 'textarea',
-				)
-			)
-		);
 	}
 
 	/**


### PR DESCRIPTION
Remove header/footer scripts as they are plugin territory and it's requested by WordPress.org